### PR TITLE
Add git-auth workspace for private repositories

### DIFF
--- a/pac/docker-build-rhtap/docker-pull-request.yaml
+++ b/pac/docker-build-rhtap/docker-pull-request.yaml
@@ -36,6 +36,9 @@ spec:
   pipelineRef:
     name: docker-build-rhtap
   workspaces:
+    - name: git-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
     - name: workspace
       volumeClaimTemplate:
         spec:

--- a/pac/docker-build-rhtap/docker-push.yaml
+++ b/pac/docker-build-rhtap/docker-push.yaml
@@ -36,6 +36,9 @@ spec:
   pipelineRef:
     name: docker-build-rhtap
   workspaces:
+    - name: git-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
     - name: workspace
       volumeClaimTemplate:
         spec:


### PR DESCRIPTION
I've been poking around with using the pipeline templates on private Git repositories (see [DEVHAS-617](https://issues.redhat.com/projects/DEVHAS/issues/DEVHAS-617?filter=allissues)), and I've found that the default pipeline templates for the pull-request and push events fail with the following error on private repos:

```
could not read Username for 'https://github.com': No such device or address
```

Consulting the [Pipelines as Code documentation for private repos](https://pipelinesascode.com/docs/guide/privaterepo/), it says that you can add a workspace referencing the Git secret for the PipelineRun, to allow the Git Clone task to succeed.

So, this PR updates the Docker pipelinerun templates for pull-request and push to add a workspace to the docker-pull-request and docker-push templates:
```
 workspaces:
    - name: git-auth
      secret:
        secretName: "{{ git_auth_secret }}"
```




