### PR TITLE
remove namespace, not required

### DIFF
--- a/pac/docker-build-rhtap/docker-pull-request.yaml
+++ b/pac/docker-build-rhtap/docker-pull-request.yaml
@@ -1,8 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: {{ values.name }}-on-pull-request
-  namespace: {{ values.namespace }}
+  name: {{ values.name }}-on-pull-request 
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"

--- a/pac/docker-build-rhtap/docker-push.yaml
+++ b/pac/docker-build-rhtap/docker-push.yaml
@@ -1,8 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: {{ values.name }}-on-push
-  namespace: {{ values.namespace }}
+  name: {{ values.name }}-on-push 
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"


### PR DESCRIPTION

The namespace is not required in the declaration and is more fragile when we move namespaces around