### PR TITLE
Fixing acs image check permission issue

### DIFF
--- a/hack/build/prepare-build-resources.sh
+++ b/hack/build/prepare-build-resources.sh
@@ -92,19 +92,33 @@ EOF
       name: rhtap-pipelines-runner
     rules:
     - apiGroups:
-      - ""
+        - tekton.dev
       resources:
-      - secrets
+        - pipelineruns
       verbs:
-      - get
+        - get
     - apiGroups:
-      - security.openshift.io
-      resourceNames:
-      - rhtap-pipelines-scc
+        - tekton.dev
       resources:
-      - securitycontextconstraints
+        - taskruns
       verbs:
-      - use
+        - get
+        - list
+        - patch
+    - apiGroups:
+        - ""
+      resources:
+        - secrets
+      verbs:
+        - get
+    - apiGroups:
+        - security.openshift.io
+      resourceNames:
+        - rhtap-pipelines-scc
+      resources:
+        - securitycontextconstraints
+      verbs:
+        - use
 EOF
 }
 


### PR DESCRIPTION
Issue facing via script:

**acs-image-scan:**
```
STEP-ANNOTATE-TASK

acs-image-scan docker-build-rhtap-acs-deploy-check
Error from server (Forbidden): taskruns.tekton.dev "docker-build-rhtap-acs-deploy-check" is forbidden: User "system:serviceaccount:test-pipeline25939:rhtap-pipeline" cannot patch resource "taskruns" in API group "tekton.dev" in the namespace "test-pipeline25939"
Error from server (Forbidden): taskruns.tekton.dev "docker-build-rhtap-acs-deploy-check" is forbidden: User "system:serviceaccount:test-pipeline25939:rhtap-pipeline" cannot patch resource "taskruns" in API group "tekton.dev" in the namespace "test-pipeline25939"
Error from server (Forbidden): taskruns.tekton.dev "docker-build-rhtap-acs-deploy-check" is forbidden: User "system:serviceaccount:test-pipeline25939:rhtap-pipeline" cannot patch resource "taskruns" in API group "tekton.dev" in the namespace "test-pipeline25939"
Error from server (Forbidden): taskruns.tekton.dev "docker-build-rhtap-acs-deploy-check" is forbidden: User "system:serviceaccount:test-pipeline25939:rhtap-pipeline" cannot patch resource "taskruns" in API group "tekton.dev" in the namespace "test-pipeline25939"
STEP-ROX-DEPLOY-CHECK

2024/03/14 06:29:00 Skipping step because a previous step failed
STEP-REPORT

2024/03/14 06:29:00 Skipping step because a previous step failed
```
@flacatus Do we have any sample template to test these pipelines. For now I am using https://github.com/prietyc123-qe-org/rhtap-go-sample 
cc @mmorhun @jduimovich 