### PR TITLE
add quotes to pac param event_type

### DIFF
--- a/pac/docker-build-rhtap/docker-pull-request.yaml
+++ b/pac/docker-build-rhtap/docker-pull-request.yaml
@@ -31,7 +31,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: event-type
-      value: {{event_type}}
+      value: '{{event_type}}'
   pipelineRef:
     name: docker-build-rhtap
   workspaces:

--- a/pac/docker-build-rhtap/docker-push.yaml
+++ b/pac/docker-build-rhtap/docker-push.yaml
@@ -31,7 +31,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: event-type
-      value: {{event_type}}
+      value: '{{event_type}}'
   pipelineRef:
     name: docker-build-rhtap
   workspaces:


### PR DESCRIPTION
When importing into tssc-sample-templates the event-type seems to get expanded to something incorrect. Adding the quotes fixes the issue