### PR TITLE
Use the ga repo for the ec task image ref

### DIFF
--- a/pac/tasks/verify-enterprise-contract.yaml
+++ b/pac/tasks/verify-enterprise-contract.yaml
@@ -88,12 +88,12 @@ spec:
     - version
     command:
     - ec
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: version
   - env:
     - name: TUF_MIRROR
       value: $(params.TUF_MIRROR)
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: initialize-tuf
     script: |-
       set -euo pipefail
@@ -142,26 +142,26 @@ spec:
       value: /tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts:$(params.SSL_CERT_DIR)
     - name: EC_CACHE
       value: "false"
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: validate
   - args:
     - $(params.HOMEDIR)/report.yaml
     command:
     - cat
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: report
   - args:
     - $(params.HOMEDIR)/report-json.json
     command:
     - cat
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: report-json
   - args:
     - .
     - $(results.TEST_OUTPUT.path)
     command:
     - jq
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: summary
   - args:
     - --argjson
@@ -173,7 +173,7 @@ spec:
     - $(results.TEST_OUTPUT.path)
     command:
     - jq
-    image: registry.redhat.io/rhtas-tech-preview/ec-rhel9:0.2
+    image: registry.redhat.io/rhtas/ec-rhel9:0.2
     name: assert
   - image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
     name: annotate-task


### PR DESCRIPTION
Since EC has been declared GA, it's now able to push to the normal repo rather than the tech preview repo.

Let's update the image reference in the verify-enterprise-contract task accordingly.

See also https://github.com/redhat-appstudio/build-definitions/pull/958 .

Ref: [EC-571](https://issues.redhat.com/browse/EC-571)