### PR TITLE
Update build-definitions references to new org

### DIFF
--- a/.github/workflows/build-definitions-sync.yaml
+++ b/.github/workflows/build-definitions-sync.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout build-definitions
         uses: actions/checkout@v4
         with:
-          repository: redhat-appstudio/build-definitions
+          repository: konflux-ci/build-definitions
           path: build-definitions
       - name: Synchronize build-definitions
         run: |

--- a/pac/tasks/gather-deploy-images.yaml
+++ b/pac/tasks/gather-deploy-images.yaml
@@ -20,7 +20,7 @@ spec:
     - name: IMAGES_TO_VERIFY
       description: >
         The images to be verified, in a format compatible with
-        https://github.com/redhat-appstudio/build-definitions/tree/main/task/verify-enterprise-contract/0.1.
+        https://github.com/konflux-ci/build-definitions/tree/main/task/verify-enterprise-contract/0.1.
         When there are no images to verify, this is an empty string.
   steps:
   - name: get-images-per-env


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
