### PR TITLE
gitops-repo: don't fail if TPA isn't configured

### DIFF
--- a/pac/gitops-repo/gitops-on-pull-request.yaml
+++ b/pac/gitops-repo/gitops-on-pull-request.yaml
@@ -20,6 +20,8 @@ spec:
     value: '{{revision}}'     
   - name: target-branch
     value: '{{target_branch}}'
+  - name: fail-if-trustification-not-configured
+    value: 'false'
   pipelineRef:
     name: gitops-pull-request
   workspaces:


### PR DESCRIPTION
Normally, if there are SBOMs to upload but TPA isn't configured, the gitops-on-pull-request pipeline will fail. Make it ignore the problem instead, at least until the installer starts creating the required Secret with TPA configuration.