### PR TITLE
Don't verify redhat-appstudio/dance-bootstrap-app

### DIFF
--- a/pac/tasks/gather-deploy-images.yaml
+++ b/pac/tasks/gather-deploy-images.yaml
@@ -53,6 +53,12 @@ spec:
             # don't check images that didn't change between the current revision and the target branch
             continue
           fi
+
+          # Workaround for RHTAPBUGS-1284
+          if [[ "$image" =~ "quay.io/redhat-appstudio/dance-bootstrap-app" ]]; then
+            # Don't check the dance-bootstrap-app image
+            continue
+          fi
         fi
 
         printf "%s\n" "$image"


### PR DESCRIPTION
Making this patch in the Tekton task to be consistent with https://github.com/redhat-appstudio/tssc-sample-jenkins/pull/4

(There should also be an upstream PR in the build-definitions repo.)

As mentioned elsewhere, I'm not sure if this is a good solution, (or if this bug would actually be a real problem in production), but I'm proposing this change as a quick workaround [RHTAPBUGS-1284](https://issues.redhat.com//browse/RHTAPBUGS-1284) for to help get testing unblocked.

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1284