### PR TITLE
Don't verify redhat-appstudio/dance-bootstrap-app

### DIFF
--- a/pac/tasks/gather-deploy-images.yaml
+++ b/pac/tasks/gather-deploy-images.yaml
@@ -53,6 +53,13 @@ spec:
             # don't check images that didn't change between the current revision and the target branch
             continue
           fi
+
+        fi
+
+        # Workaround for RHTAPBUGS-1284
+        if [[ "$image" =~ quay.io/redhat-appstudio/dance-bootstrap-app ]]; then
+          # Don't check the dance-bootstrap-app image
+          continue
         fi
 
         printf "%s\n" "$image"


### PR DESCRIPTION
Since the Jenkins version of this is merged now, see [here](https://github.com/redhat-appstudio/tssc-sample-jenkins/pull/5
), let's merge this one also to be consistent.

(There is an upstream version of this at https://github.com/konflux-ci/build-definitions/pull/1271)

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1284