### PR TITLE
fix RHTAPBUGS-1305 setup git credential helper for private repos

### DIFF
--- a/pac/tasks/acs-deploy-check.yaml
+++ b/pac/tasks/acs-deploy-check.yaml
@@ -30,12 +30,21 @@ spec:
       default: 'false'
       description: |
         When set to `"true"`, skip verifying the TLS certs of the Central endpoint. Defaults to `"false"`.
+    - name: gitops-auth-secret-name
+      type: string
+      default: gitops-auth-secret
+      description: |
+        Secret of basic-auth type containing credentials to clone the gitops repository.
   volumes:
     - name: repository
       emptyDir: {}
     - name: rox-secret
       secret:
         secretName: $(params.rox-secret-name)
+        optional: true
+    - name: gitops-auth-secret
+      secret:
+        secretName: $(params.gitops-auth-secret-name)
         optional: true
   steps:
     - name: annotate-task
@@ -55,6 +64,8 @@ spec:
           mountPath: /workspace/repository
         - name: rox-secret
           mountPath: /rox-secret
+        - name: gitops-auth-secret
+          mountPath: /gitops-auth-secret
       workingDir: /workspace/repository
       env:
         - name: PARAM_INSECURE_SKIP_TLS_VERIFY
@@ -64,6 +75,23 @@ spec:
       script: |
         #!/usr/bin/env bash
         set +x
+
+        # Check if credentials for cloning private repo are provided. Do nothing otherwise - probably public repo
+        if test -f /gitops-auth-secret/password ; then
+          gitops_repo_url=${PARAM_GITOPS_REPO_URL%'.git'}
+          remote_without_protocol=${gitops_repo_url#'https://'}
+
+          password=$(cat /gitops-auth-secret/password)
+          if test -f /gitops-auth-secret/username ; then
+            username=$(cat /gitops-auth-secret/username)
+            HOSTNAME=$(echo $PARAM_GITOPS_REPO_URL | awk -F/ '{print $3}')
+            echo "https://${username}:${password}@${HOSTNAME}" > "${HOME}/.git-credentials"
+            origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
+          else
+            origin_with_auth=https://${password}@${remote_without_protocol}.git
+          fi
+          echo -e "[credential \"https://${HOSTNAME}\"]\n  helper = store" > "${HOME}/.gitconfig"
+        fi
 
         # Check if rox API enpoint is configured
         if test -f /rox-secret/rox-api-endpoint ; then

--- a/pac/tasks/update-deployment.yaml
+++ b/pac/tasks/update-deployment.yaml
@@ -40,11 +40,13 @@ spec:
           password=$(cat /gitops-auth-secret/password)
           if test -f /gitops-auth-secret/username ; then
             username=$(cat /gitops-auth-secret/username)
-            echo "https://${username}:${password})@${hostname}" > "${HOME}/.git-credentials"
+            HOSTNAME=$(echo $PARAM_GITOPS_REPO_URL | awk -F/ '{print $3}')
+            echo "https://${username}:${password}@${HOSTNAME}" > "${HOME}/.git-credentials"
             origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
           else
             origin_with_auth=https://${password}@${remote_without_protocol}.git
           fi
+          echo -e "[credential \"https://${HOSTNAME}\"]\n  helper = store" > "${HOME}/.gitconfig"
         else
           echo "git credentials to push into gitops repository ${PARAM_GITOPS_REPO_URL} is not configured."
           echo "gitops repository is not updated automatically."


### PR DESCRIPTION
update-deployment was using empty variable `${hostname}` and it also wasn't setting up the `~/.gitconfig` properly.

In acs-deploy-check, no credentials were being used whatsoever, so the gitops repo clone failed which caused failure of that task.