### PR TITLE
[RHTAPBUGS-1305] Add gitops-auth workspace

### DIFF
--- a/pac/source-repo/docker-push.yaml
+++ b/pac/source-repo/docker-push.yaml
@@ -37,6 +37,9 @@ spec:
   pipelineRef:
     name: docker-build-rhtap
   workspaces:
+    - name: gitops-auth
+      secret:
+        secretName: $(params.gitops-auth-secret-name)
     - name: git-auth
       secret:
         secretName: "{{ git_auth_secret }}"


### PR DESCRIPTION
This PR adds gitops-auth workspace to adjust for [RHTAPBUGS-1305](https://issues.redhat.com//browse/RHTAPBUGS-1305) fix (https://github.com/redhat-appstudio/tssc-sample-pipelines/pull/56)