### PR TITLE
Sync ec task from build-definitions

### DIFF
--- a/pac/tasks/verify-enterprise-contract.yaml
+++ b/pac/tasks/verify-enterprise-contract.yaml
@@ -96,13 +96,29 @@ spec:
       "key=value,key2=value2..."
     name: EXTRA_RULE_DATA
     type: string
-  - default: 5m0s
-    description: Timeout setting for `ec validate`.
+  - default: ""
+    description: |
+      This param is deprecated and will be removed in future. Its value is ignored. EC will be run without a timeout. (If you do want to apply a timeout use the Tekton task timeout.)
     name: TIMEOUT
     type: string
   - default: "1"
     description: Number of parallel workers to use for policy evaluation.
     name: WORKERS
+    type: string
+  - default: "false"
+    description: Reduce the Snapshot to only the component whose build caused the
+      Snapshot to be created
+    name: SINGLE_COMPONENT
+    type: string
+  - default: unknown
+    description: |
+      Name, including kind, of the Kubernetes resource to query for labels when single component mode is enabled, e.g. pr/somepipeline.
+    name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+    type: string
+  - default: ""
+    description: |
+      Kubernetes namespace where the SINGLE_COMPONENT_NAME is found. Only used when single component mode is enabled.
+    name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
     type: string
   results:
   - description: Short summary of the policy evaluation for each image
@@ -115,7 +131,7 @@ spec:
   - env:
     - name: TUF_MIRROR
       value: $(params.TUF_MIRROR)
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: initialize-tuf
     script: |-
       set -euo pipefail
@@ -128,12 +144,28 @@ spec:
       echo 'Initializing TUF root...'
       ec sigstore initialize --mirror "${TUF_MIRROR}" --root "${TUF_MIRROR}/root.json"
       echo 'Done!'
+  - command:
+    - reduce-snapshot.sh
+    env:
+    - name: SNAPSHOT
+      value: $(params.IMAGES)
+    - name: SINGLE_COMPONENT
+      value: $(params.SINGLE_COMPONENT)
+    - name: CUSTOM_RESOURCE
+      value: $(params.SINGLE_COMPONENT_CUSTOM_RESOURCE)
+    - name: CUSTOM_RESOURCE_NAMESPACE
+      value: $(params.SINGLE_COMPONENT_CUSTOM_RESOURCE_NS)
+    - name: SNAPSHOT_PATH
+      value: $(params.HOMEDIR)/snapshot.json
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
+    name: reduce
+    onError: continue
   - args:
     - validate
     - image
     - --verbose
     - --images
-    - $(params.IMAGES)
+    - /tekton/home/snapshot.json
     - --policy
     - $(params.POLICY_CONFIGURATION)
     - --public-key
@@ -144,15 +176,13 @@ spec:
     - --workers
     - $(params.WORKERS)
     - --info=$(params.INFO)
-    - --timeout=$(params.TIMEOUT)
+    - --timeout=100h
     - --strict=false
     - --show-successes
     - --effective-time=$(params.EFFECTIVE_TIME)
     - --extra-rule-data=$(params.EXTRA_RULE_DATA)
     - --output
     - text?show-successes=false
-    - --output
-    - yaml=$(params.HOMEDIR)/report.yaml
     - --output
     - appstudio=$(results.TEST_OUTPUT.path)
     - --output
@@ -171,7 +201,7 @@ spec:
       value: /tekton-custom-certs:/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts:$(params.SSL_CERT_DIR)
     - name: EC_CACHE
       value: "false"
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: validate
     onError: continue
     volumeMounts:
@@ -180,17 +210,10 @@ spec:
       readOnly: true
       subPath: ca-bundle.crt
   - args:
-    - $(params.HOMEDIR)/report.yaml
-    command:
-    - cat
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
-    name: report
-    onError: continue
-  - args:
     - $(params.HOMEDIR)/report-json.json
     command:
     - cat
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: report-json
     onError: continue
   - args:
@@ -198,7 +221,7 @@ spec:
     - $(results.TEST_OUTPUT.path)
     command:
     - jq
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: summary
     onError: continue
   - args:
@@ -206,19 +229,19 @@ spec:
       ----- DEBUG OUTPUT -----
     command:
     - printf
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: info
   - args:
     - version
     command:
     - ec
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: version
   - args:
     - $(params.HOMEDIR)/debug.log
     command:
     - cat
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: debug-log
   - args:
     - --argjson
@@ -230,7 +253,7 @@ spec:
     - $(results.TEST_OUTPUT.path)
     command:
     - jq
-    image: registry.redhat.io/rhtas/ec-rhel9:0.5
+    image: registry.redhat.io/rhtas/ec-rhel9:0.6
     name: assert
   - image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
     name: annotate-task


### PR DESCRIPTION
This brings an updated version of the EC task definition that uses the 0.6 version.

The issue with the missing reduce-snapshot.sh script has been addressed, RHTAP-4567.