### PR TITLE
Update TPA API version to v2

### DIFF
--- a/pac/tasks/upload-sbom-to-trustification.yaml
+++ b/pac/tasks/upload-sbom-to-trustification.yaml
@@ -262,7 +262,7 @@ spec:
           -H "transfer-encoding: chunked" \
           -H "content-type: application/json" \
           --data "@$supported_version_of_sbom" \
-          "$bombastic_api_url/api/v1/sbom?id=$sbom_id"
+          "$bombastic_api_url/api/v2/sbom?id=$sbom_id"
       done
 
   - name: report


### PR DESCRIPTION
TPA version changed to v2 after upgrading to TPA-2.0.0
This PR should be merged with https://github.com/redhat-appstudio/rhtap-cli/pull/779