### PR TITLE
fix: improve acs-image-check output

### DIFF
--- a/pac/tasks/acs-image-check.yaml
+++ b/pac/tasks/acs-image-check.yaml
@@ -181,6 +181,8 @@ spec:
         then
           echo "Error occurred during roxctl image check, please check the logs of rox-image-check step."
           exit "$ROX_IMAGE_CHECK_STATUS"
+        else
+          echo "Note: Violations are reported for informational purposes only and do not cause the task to fail."
         fi
 
         echo "No errors occurred"


### PR DESCRIPTION
cf RHTAP-5243

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED