### PR TITLE
chore: update references to ec config repo

### DIFF
--- a/hack/patches/pipelines/gitops-pull-request/patch.yaml
+++ b/hack/patches/pipelines/gitops-pull-request/patch.yaml
@@ -1,9 +1,9 @@
 - op: replace
   # The 3 indexed param is expected to be 'ec-policy-configuration'
   path: /spec/params/3/default
-  # The original value here is 'github.com/enterprise-contract/config//default'
+  # The original value here is 'github.com/conforma/config//default'
   # which specifies a config file that pulls in the latest rego rules from the main
   # branch in the enterprise-contract/ec-policies repo. Change it to a config file
   # that uses a stable release branch of the ec-policies repo for better stability
   # in general, and better ongoing compatibility with ec v0.4.
-  value: github.com/enterprise-contract/config//tekton-slsa3-v0.6
+  value: github.com/conforma/config//tekton-slsa3-v0.6

--- a/pac/pipelines/gitops-pull-request-rhtap.yaml
+++ b/pac/pipelines/gitops-pull-request-rhtap.yaml
@@ -15,7 +15,7 @@ spec:
     description: The target branch for the pull request
     name: target-branch
     type: string
-  - default: github.com/enterprise-contract/config//tekton-slsa3-v0.6
+  - default: github.com/conforma/config//tekton-slsa3-v0.6
     description: Enterprise Contract policy to validate against
     name: ec-policy-configuration
     type: string

--- a/pac/tasks/verify-enterprise-contract.yaml
+++ b/pac/tasks/verify-enterprise-contract.yaml
@@ -34,7 +34,7 @@ spec:
       resource) to use. `namespace/name` or `name` syntax supported. If
       namespace is omitted the namespace where the task runs is used.
       You can also specify a policy configuration using a git url, e.g.
-      `github.com/enterprise-contract/config//slsa3`.
+      `github.com/conforma/config//slsa3`.
     name: POLICY_CONFIGURATION
     type: string
   - default: ""


### PR DESCRIPTION
This commit updates references to the ec config repo from `enterprise-contract/config` to `conforma/config`.

Ref: [EC-1115](https://issues.redhat.com//browse/EC-1115)