### PR TITLE
Fix yaml consistency

### DIFF
--- a/hack/import-build-definitions
+++ b/hack/import-build-definitions
@@ -96,9 +96,6 @@ for pipeline in $OUTPUT_PIPELINES_DIR/* ;  do
     else
       echo Unable to apply task in $VERSIONDIR
     fi
-
-    # Apply consistent style
-    yq -i '.' "$OUTPUT_TASKS_DIR/$task.yaml"
   done
 done
 
@@ -106,3 +103,12 @@ echo
 echo "update-pipelinerun-imports"
 bash $SCRIPTDIR/update-pipelinerun-imports
 bash $SCRIPTDIR/patch-tasks
+
+echo 'ensure consistent formatting'
+tasks=("${OUTPUT_TASKS_DIR}"/*.yaml)
+pipelines=("${OUTPUT_PIPELINES_DIR}"/*.yaml)
+all=( "${tasks[@]}" "${pipelines[@]}")
+for f in "${all[@]}"; do
+    yq -i --prettyPrint --indent=2 '.' "${f}"
+done
+

--- a/pac/tasks/acs-deploy-check.yaml
+++ b/pac/tasks/acs-deploy-check.yaml
@@ -10,8 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
 spec:
-  description: >-
-    Policy check a deployment with StackRox/RHACS This tasks allows you to check a deployment against build-time policies and apply enforcement to fail builds. It's a companion to the stackrox-image-scan task, which returns full vulnerability scan results for an image.
+  description: Policy check a deployment with StackRox/RHACS This tasks allows you to check a deployment against build-time policies and apply enforcement to fail builds. It's a companion to the stackrox-image-scan task, which returns full vulnerability scan results for an image.
   params:
     - name: rox-secret-name
       type: string
@@ -23,10 +22,10 @@ spec:
       description: URL of gitops repository to check.
     - name: verbose
       type: string
-      default: 'true'
+      default: "true"
     - name: insecure-skip-tls-verify
       type: string
-      default: 'false'
+      default: "false"
       description: |
         When set to `"true"`, skip verifying the TLS certs of the Central endpoint. Defaults to `"false"`.
     - name: gitops-auth-secret-name

--- a/pac/tasks/buildah-rhtap.yaml
+++ b/pac/tasks/buildah-rhtap.yaml
@@ -3,10 +3,10 @@ kind: Task
 metadata:
   labels:
     app.kubernetes.io/version: "0.1"
-    build.appstudio.redhat.com/build_type: "docker"
+    build.appstudio.redhat.com/build_type: docker
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "containers, rhtap"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: containers, rhtap
   name: buildah-rhtap
 spec:
   description: |-
@@ -217,7 +217,8 @@ spec:
       workingDir: /tmp/files
     - name: upload-sbom
       image: registry.redhat.io/rhtas/cosign-rhel9:e28487714294d5c205e95da843e86fd28e4d3355d6a4d328a872c62ed0cf5f93@sha256:6fa39582a3d62a2aa5404397bb638fdd0960f9392db659d033d7bacf70bddfb1
-      command: [cosign]
+      command:
+        - cosign
       args:
         - attach
         - sbom

--- a/pac/tasks/download-sbom-from-url-in-attestation.yaml
+++ b/pac/tasks/download-sbom-from-url-in-attestation.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    tekton.dev/tags: "sbom, attestation, cosign"
+    tekton.dev/tags: sbom, attestation, cosign
   name: download-sbom-from-url-in-attestation
   labels:
     app.kubernetes.io/version: "0.1"
@@ -35,22 +35,19 @@ spec:
     [gather-deploy-images]: https://github.com/redhat-appstudio/build-definitions/tree/main/task/gather-deploy-images
   params:
     - name: IMAGES
-      description: >-
-        JSON object containing the array of images whose SBOMs should be downloaded. See the description for more details.
+      description: JSON object containing the array of images whose SBOMs should be downloaded. See the description for more details.
       type: string
     - name: SBOMS_DIR
-      default: "."
-      description: >-
-        Path to directory (relative to the 'sboms' workspace) where SBOMs should be downloaded.
+      default: .
+      description: Path to directory (relative to the 'sboms' workspace) where SBOMs should be downloaded.
       type: string
     - name: HTTP_RETRIES
       default: "3"
-      description: "Maximum number of retries for transient HTTP(S) errors"
+      description: Maximum number of retries for transient HTTP(S) errors
       type: string
     - name: PUBLIC_KEY
       type: string
-      description: >-
-        Public key used to verify signatures. Must be a valid k8s cosign reference, e.g. k8s://my-space/my-secret where my-secret contains the expected cosign.pub attribute.
+      description: Public key used to verify signatures. Must be a valid k8s cosign reference, e.g. k8s://my-space/my-secret where my-secret contains the expected cosign.pub attribute.
       default: ""
     - name: REKOR_HOST
       type: string
@@ -58,8 +55,7 @@ spec:
       default: ""
     - name: IGNORE_REKOR
       type: string
-      description: >-
-        Skip Rekor transparency log checks during validation.
+      description: Skip Rekor transparency log checks during validation.
       default: "false"
     - name: TUF_MIRROR
       type: string

--- a/pac/tasks/gather-deploy-images.yaml
+++ b/pac/tasks/gather-deploy-images.yaml
@@ -11,20 +11,21 @@ spec:
       name: source
   params:
     - name: TARGET_BRANCH
-      description: >
+      description: |
         If specified, will gather only the images that changed between the current revision and the target branch. Useful for pull requests. Note that the repository cloned on the source workspace must already contain the origin/$TARGET_BRANCH reference.
-
       type: string
       default: ""
     - name: ENVIRONMENTS
       description: Gather images from the manifest files for the specified environments
       type: array
-      default: ["development", "stage", "prod"]
+      default:
+        - development
+        - stage
+        - prod
   results:
     - name: IMAGES_TO_VERIFY
-      description: >
+      description: |
         The images to be verified, in a format compatible with https://github.com/konflux-ci/build-definitions/tree/main/task/verify-enterprise-contract/0.1. When there are no images to verify, this is an empty string.
-
   steps:
     - name: get-images-per-env
       image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c

--- a/pac/tasks/git-clone.yaml
+++ b/pac/tasks/git-clone.yaml
@@ -11,8 +11,7 @@ metadata:
     tekton.dev/tags: git
   name: git-clone
 spec:
-  description: |-
-    The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace.
+  description: The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace.
   params:
     - description: Repository URL to clone from.
       name: url
@@ -41,7 +40,7 @@ spec:
       description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
       name: sslVerify
       type: string
-    - default: "source"
+    - default: source
       description: Subdirectory inside the `output` Workspace to clone the repo into.
       name: subdirectory
       type: string
@@ -101,7 +100,7 @@ spec:
     - name: targetBranch
       description: The target branch to merge into the revision (if mergeTargetBranch is true).
       type: string
-      default: "main"
+      default: main
   results:
     - description: The precise commit SHA that was fetched by this Task.
       name: commit

--- a/pac/tasks/init.yaml
+++ b/pac/tasks/init.yaml
@@ -4,12 +4,11 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.2"
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "konflux"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
   name: init
 spec:
-  description: >-
-    Initialize Pipeline Task, include flags for rebuild and auth. Generates image repository secret used by the PipelineRun.
+  description: Initialize Pipeline Task, include flags for rebuild and auth. Generates image repository secret used by the PipelineRun.
   params:
     - name: image-url
       description: Image URL for build by PipelineRun

--- a/pac/tasks/show-sbom-rhdh.yaml
+++ b/pac/tasks/show-sbom-rhdh.yaml
@@ -5,16 +5,15 @@ metadata:
   name: show-sbom-rhdh
   labels:
     app.kubernetes.io/version: "0.1"
-    build.appstudio.redhat.com/build_type: "docker"
+    build.appstudio.redhat.com/build_type: docker
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "containers, rhtap"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: containers, rhtap
     task.results.format: application/text
     task.results.key: LINK_TO_SBOM
     task.output.location: results
 spec:
-  description: >-
-    Shows the Software Bill of Materials (SBOM) generated for the built image. The 'task.*' annotations are processed by Red Hat Developer Hub (RHDH) so that the log content can be rendered in its UI.
+  description: Shows the Software Bill of Materials (SBOM) generated for the built image. The 'task.*' annotations are processed by Red Hat Developer Hub (RHDH) so that the log content can be rendered in its UI.
   params:
     - name: IMAGE_URL
       description: Fully qualified image name to show SBOM for.

--- a/pac/tasks/summary.yaml
+++ b/pac/tasks/summary.yaml
@@ -4,12 +4,11 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.2"
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "konflux"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
   name: summary
 spec:
-  description: >-
-    Summary Pipeline Task. Prints PipelineRun information, removes image repository secret used by the PipelineRun.
+  description: Summary Pipeline Task. Prints PipelineRun information, removes image repository secret used by the PipelineRun.
   params:
     - name: pipelinerun-name
       description: pipeline-run to annotate
@@ -40,7 +39,7 @@ spec:
         - name: BUILD_TASK_STATUS
           value: $(params.build-task-status)
         - name: SOURCE_BUILD_RESULT_FILE
-          value: "$(workspaces.workspace.path)/source_build_result.json"
+          value: $(workspaces.workspace.path)/source_build_result.json
       script: |
         #!/usr/bin/env bash
         echo

--- a/pac/tasks/update-deployment.yaml
+++ b/pac/tasks/update-deployment.yaml
@@ -33,7 +33,7 @@ spec:
           value: $(workspaces.gitops-auth.bound)
         - name: WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH
           value: $(workspaces.gitops-auth.path)
-      script: |
+      script: |2
         if [ "${WORKSPACE_GITOPS_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
           if [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
             cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.git-credentials" "${HOME}/.git-credentials"

--- a/pac/tasks/upload-sbom-to-trustification.yaml
+++ b/pac/tasks/upload-sbom-to-trustification.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    tekton.dev/tags: "sbom, trustification"
+    tekton.dev/tags: sbom, trustification
   name: upload-sbom-to-trustification
   labels:
     app.kubernetes.io/version: "0.1"
@@ -32,13 +32,12 @@ spec:
         `syft convert` to the supported version before uploading.
   params:
     - name: SBOMS_DIR
-      default: "."
-      description: >-
-        Directory containing SBOM files. The task will search for CycloneDX JSON SBOMs recursively in this directory and upload them all to Trustification. The path is relative to the 'sboms' workspace.
+      default: .
+      description: Directory containing SBOM files. The task will search for CycloneDX JSON SBOMs recursively in this directory and upload them all to Trustification. The path is relative to the 'sboms' workspace.
       type: string
     - name: HTTP_RETRIES
       default: "3"
-      description: "Maximum number of retries for transient HTTP(S) errors"
+      description: Maximum number of retries for transient HTTP(S) errors
       type: string
     - name: TRUSTIFICATION_SECRET_NAME
       default: trustification-secret
@@ -46,8 +45,7 @@ spec:
       type: string
     - name: FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED
       default: "true"
-      description: >-
-        Should the task fail if the Secret does not contain the required keys? (Set "true" to fail, "false" to skip uploading and exit with success).
+      description: Should the task fail if the Secret does not contain the required keys? (Set "true" to fail, "false" to skip uploading and exit with success).
       type: string
   workspaces:
     - name: sboms


### PR DESCRIPTION
This change alters the `import-build-definitions` script to apply the yq command to tasks and pipelines at the very end. It also explicitly sets the expected output format. YAML lint is now successful with these changes.